### PR TITLE
small changes to dawn onboarding

### DIFF
--- a/src/onboarding/index.html
+++ b/src/onboarding/index.html
@@ -53,10 +53,10 @@
                 Ghostery Glow is built into Ghostery Dawn browser. This one-of-a-kind search engine does not log your search history, which means you get served objective results, not results that are filtered by the likelihood you’ll click on them.
               </div>
               <div class="hidden description" data-description-for="search2">
-                DuckDuckGo emphasizes protecting searchers’ privacy and avoiding the filter bubble of personalized search results. DuckDuckGo does not show search results from content farms.
+                DuckDuckGo emphasizes protecting searchers’ privacy and avoiding the filter bubble of personalized search results.
               </div>
               <div class="hidden description" data-description-for="search3">
-                Startpage highlights privacy as its distinguishing feature. They allow users to obtain Google Search results while protecting users’ privacy by not storing personal information or search data and removing all trackers.
+                Startpage highlights privacy as its distinguishing feature. It allows users to obtain Google Search results while protecting users’ privacy by not storing personal information or search data and removing all trackers.
               </div>
               <div class="hidden description" data-description-for="search4">
                 Microsoft Bing helps you find trusted search results fast, tracks topics and trending stories that matter to you, and gives you control of your privacy.


### PR DESCRIPTION
unfortunately I cannot lower the market share numbers of google as checking multiple sources, they state similar numbers:
91.9% gs.statcounter January 2022
92.47% statista June 2021